### PR TITLE
upgrade modules and provider versions, applied terraform fmt

### DIFF
--- a/terraform/groups/ecs-service/.terraform.lock.hcl
+++ b/terraform/groups/ecs-service/.terraform.lock.hcl
@@ -1,0 +1,48 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.52.0"
+  constraints = ">= 4.0.0, >= 6.0.0, < 7.0.0"
+  hashes = [
+    "h1:8m5zm0JaUac+YikXZoZDTV7R0iYL+q3IvTL4Ac8GfDA=",
+    "h1:Dg9X3Gde96OCT3TovLKAKumnR64VqIIQ37m/9NRJ00Y=",
+    "zh:1ab1d78f2336fed42b4e13fa0077a0be9d86a7899897cda5b9f1a60051ec2e93",
+    "zh:1df11f5f252030803939a1c778931dbdcee1b1070b38b98d9a8cbfc26c2aeb8e",
+    "zh:20ec9af03c0c1f2f8582a8805d43a4cd1a0a65082308e00f025d87605715a88f",
+    "zh:2d5562ed0e7cb0892fb537c7989d25fdde1d0ac1f3a768ba15fa087985f2a0f5",
+    "zh:40d64f668961a172355c3d11d258e19172ffafb421c40d89266b129ed8f92a5d",
+    "zh:497792bccc33001247473bc32a148c067982cb3d245b8f3610afb920635d2235",
+    "zh:8011f9167082af74ed9257582a83d54e889388656597721b2691797f1dd6fb58",
+    "zh:8b10d1bbca51b0da1e1be0967ce75b039f2d5d86f2ca7339994a92d35cdf47a8",
+    "zh:9549647dbf7c913512c26fed6badd7bf24a29a36c2bd308536849303a85427da",
+    "zh:97c4b726cdbe48166f4b9e6a1230312a7933dc19dd139d941ca6aca86706eb33",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a484bc8166278b546bfe53698fa9e0a919dffe3bfda3c8bf8a0fc6811b5b9e66",
+    "zh:aa96e76bd9f93e5395a553fccec485554a74acae46b3834b1296374eba4f010f",
+    "zh:cf290ee3d0dfe91b596445f860440d9f18826f7395ff785f83f70d36cedadd1c",
+    "zh:d56b6a79207663673f66d9ed378d705c1bd1b4d117eeb5e2be3938cf1b75b7be",
+    "zh:febef068317f8e49bd438ccdf2f54345fc3bc4b80a2699d9ab3c449d7e521d8e",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/vault" {
+  version     = "5.10.1"
+  constraints = ">= 5.0.0, < 6.0.0"
+  hashes = [
+    "h1:gE6FVZ+6NXhwd9bOnL0ARFNw94dDiAICRxoXXuRTuas=",
+    "h1:lyFssgWG/91rFC++zoiJQDaqhzWieLL64bIF6+53Hq4=",
+    "zh:0de49889bc7cfb66f9004651252e4c38acb0c927335ce0cbe1ee59a576030a44",
+    "zh:1875cbcbac4bf19f2e9f9bd6f7a4589419f65969676c879b5c80ca4823818011",
+    "zh:32f51e4eae2157a3c56ff40cd72f218776a9a8cc2151a6d78a36078c87243ac7",
+    "zh:7674d317e9337da84daec86d1b4610392eb3838369198011fe79b6980acb8632",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7f9b9322cf83ea17ae218199bb9f482699e2ea481ba1c2e4c9f81dffc0e9a43c",
+    "zh:808dcb981408ef066a0c4cc412ba181924616157c29d5b404b7a5c6d6d6e7386",
+    "zh:8bbd07729da50f55606ae7a3a8ef0624ace110da31465753e5552abbde43233a",
+    "zh:9c798262c364afcef6630b2d290c19b763071c561b90cf051d87ad56b369cd89",
+    "zh:d90fcc9b1e740ee0c0ea6e123ec964f2e1cdbf65a1dba1786e65e2a827880e72",
+    "zh:f07e029e576786b6d4af488fdb7da2a4bbd0509e6dacfbd73230a1503e3c085e",
+    "zh:f2e5070b9a7fca6a0fe857db4d3df0f2a182567178058b764bdbfb4199ae113b",
+  ]
+}

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -1,24 +1,24 @@
 # Define all hardcoded local variable and local variables looked up from data resources
 locals {
-  stack_name                  = "payments-service" # this must match the stack name the service deploys into
-  name_prefix                 = "${local.stack_name}-${var.environment}"
-  global_prefix               = "global-${var.environment}"
-  service_name                = "refund-request-consumer-java"
-  container_port              = "8081"
-  docker_repo                 = "refund-request-consumer-java"
-  kms_alias                   = "alias/${var.aws_profile}/environment-services-kms"
-  healthcheck_path            = "/healthcheck"
-  healthcheck_matcher         = "200"
-  vpc_name                    = local.stack_secrets["vpc_name"]
-  s3_config_bucket            = data.vault_generic_secret.shared_s3.data["config_bucket_name"]
-  app_environment_filename    = "refund-request-consumer-java.env"
-  use_set_environment_files   = var.use_set_environment_files
-  application_subnet_ids      = data.aws_subnets.application.ids
+  stack_name                = "payments-service" # this must match the stack name the service deploys into
+  name_prefix               = "${local.stack_name}-${var.environment}"
+  global_prefix             = "global-${var.environment}"
+  service_name              = "refund-request-consumer-java"
+  container_port            = "8081"
+  docker_repo               = "refund-request-consumer-java"
+  kms_alias                 = "alias/${var.aws_profile}/environment-services-kms"
+  healthcheck_path          = "/healthcheck"
+  healthcheck_matcher       = "200"
+  vpc_name                  = local.stack_secrets["vpc_name"]
+  s3_config_bucket          = data.vault_generic_secret.shared_s3.data["config_bucket_name"]
+  app_environment_filename  = "refund-request-consumer-java.env"
+  use_set_environment_files = var.use_set_environment_files
+  application_subnet_ids    = data.aws_subnets.application.ids
 
   stack_secrets              = jsondecode(data.vault_generic_secret.stack_secrets.data_json)
   application_subnet_pattern = local.stack_secrets["application_subnet_pattern"]
 
-  service_secrets            = jsondecode(data.vault_generic_secret.service_secrets.data_json)
+  service_secrets = jsondecode(data.vault_generic_secret.service_secrets.data_json)
 
   # create a map of secret name => secret arn to pass into ecs service module
   # using the trimprefix function to remove the prefixed path from the secret name
@@ -43,8 +43,8 @@ locals {
   ]
 
   service_secrets_arn_map = {
-    for sec in module.secrets.secrets:
-      trimprefix(sec.name, "/${local.service_name}-${var.environment}/") => sec.arn
+    for sec in module.secrets.secrets :
+    trimprefix(sec.name, "/${local.service_name}-${var.environment}/") => sec.arn
   }
 
   service_secret_list = flatten([for key, value in local.service_secrets_arn_map :
@@ -58,9 +58,9 @@ locals {
   ]
 
   # secrets to go in list
-  task_secrets = concat(local.service_secret_list,local.global_secret_list)
+  task_secrets = concat(local.service_secret_list, local.global_secret_list)
 
-  task_environment = concat(local.ssm_global_version_map,local.ssm_service_version_map,[
+  task_environment = concat(local.ssm_global_version_map, local.ssm_service_version_map, [
     { name : "PORT", value : local.container_port },
   ])
 }

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -3,23 +3,23 @@ provider "aws" {
 }
 
 terraform {
-  backend "s3" {
-  }
-  required_version = "~> 1.3"
+  required_version = ">= 1.3.0, < 2.0.0"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.54.0"
+      version = ">= 6.0, < 7.0"
     }
     vault = {
       source  = "hashicorp/vault"
-      version = "~> 3.18.0"
+      version = ">= 5.0, < 6.0"
     }
   }
+  backend "s3" {}
 }
 
 module "ecs-service" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.353"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.390"
 
 
   # Environmental configuration
@@ -29,7 +29,7 @@ module "ecs-service" {
   vpc_id                  = data.aws_vpc.vpc.id
   ecs_cluster_id          = data.aws_ecs_cluster.ecs_cluster.id
   task_execution_role_arn = data.aws_iam_role.ecs_cluster_iam_role.arn
-  batch_service = true
+  batch_service           = true
 
   # ECS Task container health check
   use_task_container_healthcheck = true
@@ -37,14 +37,14 @@ module "ecs-service" {
   healthcheck_matcher            = local.healthcheck_matcher
 
   # Docker container details
-  docker_registry     = var.docker_registry
-  docker_repo         = local.docker_repo
-  container_version   = var.refund_request_consumer_java_version
-  container_port      = local.container_port
+  docker_registry   = var.docker_registry
+  docker_repo       = local.docker_repo
+  container_version = var.refund_request_consumer_java_version
+  container_port    = local.container_port
 
   # Service configuration
   service_name = local.service_name
-  name_prefix = local.name_prefix
+  name_prefix  = local.name_prefix
 
   # Service performance and scaling configs
   desired_task_count                   = var.desired_task_count
@@ -59,7 +59,7 @@ module "ecs-service" {
   service_scaleup_schedule             = var.service_scaleup_schedule
   use_capacity_provider                = var.use_capacity_provider
   use_fargate                          = var.use_fargate
-  fargate_subnets                       = local.application_subnet_ids
+  fargate_subnets                      = local.application_subnet_ids
 
   # Service environment variable and secret configs
   task_environment          = local.task_environment
@@ -69,8 +69,8 @@ module "ecs-service" {
 }
 
 module "secrets" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/parameter-store?ref=1.0.353"
+  source      = "git@github.com:companieshouse/terraform-modules//aws/parameter-store?ref=1.0.390"
   name_prefix = "${local.service_name}-${var.environment}"
   kms_key_id  = data.aws_kms_key.kms_key.id
-  secrets = nonsensitive(local.service_secrets)
+  secrets     = nonsensitive(local.service_secrets)
 }

--- a/terraform/groups/ecs-service/vault-providers/userpass
+++ b/terraform/groups/ecs-service/vault-providers/userpass
@@ -1,11 +1,11 @@
 variable "hashicorp_vault_username" {
   description = "The username used when retrieving configuration from Hashicorp Vault"
-  type = string
+  type        = string
 }
 
 variable "hashicorp_vault_password" {
   description = "The password used when retrieving configuration from Hashicorp Vault"
-  type = string
+  type        = string
 }
 
 provider "vault" {


### PR DESCRIPTION

### Related Jira tickets
`ASM-2204`

### General

- Upgraded `ecs service` and `secrets` modules to the latest ref
- Raised provider constraints: AWS `>= 6.0, < 7.0` , Vault `>= 5.0, < 6.0`
- Set required_version to `>= 1.3.0, < 2.0.0`
- Regenerated `.terraform.lock.hcl`
- Applied `terraform fmt`

### Plan summary

- `No changes. Your infrastructure matches the configuration.`